### PR TITLE
Add config option for basedir

### DIFF
--- a/lib/jadeify.js
+++ b/lib/jadeify.js
@@ -1,7 +1,29 @@
 "use strict";
 
+var path = require("path");
 var through = require("through");
 var jade = require("jade");
+var findParent = require("find-parent-dir");
+
+
+function readPackage (pathName, cb) {
+    findParent(pathName, "package.json", function (err, dir) {
+        if (err) {
+            return cb(err);
+        }
+        if (!dir) {
+            return cb(null, null);
+        }
+        var fileName = path.join(dir, "package.json");
+        var pkg = null;
+        try {
+            pkg = require(fileName);
+        } catch (e) {
+            return cb(e);
+        }
+        cb(null, pkg);
+    });
+}
 
 module.exports = function (fileName) {
     if (!/\.jade$/i.test(fileName)) {
@@ -15,27 +37,32 @@ module.exports = function (fileName) {
             inputString += chunk;
         },
         function () {
-            var opts = { filename: fileName, compileDebug: false };
+            var self = this;
+            readPackage(process.cwd(), function (err, pkg) {
+                var opts = pkg && pkg.jadeify || {};
+                opts.filename = fileName;
+                opts.compileDebug = false;
 
-            var templateFunction;
+                var templateFunction;
 
-            try {
-                if (jade.compileClient) {
-                    templateFunction = jade.compileClient(inputString, opts);
-                } else {
-                    opts.client = true;
-                    templateFunction = jade.compile(inputString, opts);
+                try {
+                    if (jade.compileClient) {
+                        templateFunction = jade.compileClient(inputString, opts);
+                    } else {
+                        opts.client = true;
+                        templateFunction = jade.compile(inputString, opts);
+                    }
+                } catch (e) {
+                    self.emit("error", e);
+                    return;
                 }
-            } catch (e) {
-                this.emit("error", e);
-                return;
-            }
 
-            var moduleBody = "var jade = require(\"jade/runtime\");\n\n" +
-                             "module.exports = " + templateFunction.toString() + ";";
+                var moduleBody = "var jade = require(\"jade/runtime\");\n\n" +
+                                 "module.exports = " + templateFunction.toString() + ";";
 
-            this.queue(moduleBody);
-            this.queue(null);
+                self.queue(moduleBody);
+                self.queue(null);
+            });
         }
     );
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "lint": "jshint lib"
     },
     "dependencies": {
+        "find-parent-dir": "^0.3.0",
         "through": "^2.3.4"
     },
     "peerDependencies": {


### PR DESCRIPTION
When template files are deeply nested, it is good to use `include` and `extends` relative to templates root so you don't have to `../../` to parent dir. 

Jade has `basedir` option so [you're able to `include /mixins`](https://github.com/visionmedia/jade/pull/989).

Would be good if jadeify also supported this option.
