### PR TITLE
Update browserify peer dependency to < 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "through": "^2.3.6"
   },
   "peerDependencies": {
-    "browserify": ">= 2.4.0 < 9",
+    "browserify": ">= 2.4.0 < 10",
     "jade": "^1.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Everything seems to be fine with browserify@9.0.3.

Closes #27.