### PR TITLE
Update browserify peer dependency for v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "through": "^2.3.6"
   },
   "peerDependencies": {
-    "browserify": ">= 2.4.0 < 10",
+    "browserify": ">= 2.4.0 < 11",
     "jade": "^1.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
From what I can tell, it looks ok to bump up. Here is the browserify [changelog](https://github.com/substack/node-browserify/blob/b9727cfcb4fe2d03e11e517e5f41c37704ec5f39/changelog.markdown)