### PR TITLE
Update browserify peer dependency for v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "through": "^2.3.6"
   },
   "peerDependencies": {
-    "browserify": ">= 2.4.0 < 11",
+    "browserify": ">= 2.4.0 < 12",
     "jade": "^1.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Looks ok from the [browserify changelog](https://github.com/substack/node-browserify/blob/master/changelog.markdown).