### PR TITLE
Bump browserify restriction. Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - iojs
+  - "5.0"
 script:
   npm run lint && npm test

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "through": "^2.3.6"
   },
   "peerDependencies": {
-    "browserify": ">= 2.4.0 < 12",
+    "browserify": ">= 2.4.0 <= 13",
     "jade": "^1.9.2"
   },
   "devDependencies": {
-    "browserify": "^11.0.0",
+    "browserify": "^12.0.1",
     "concat-stream": "^1.5.0",
     "jade": "^1.11.0",
-    "jsdom": "^5.6.1",
+    "jsdom": "^7.0.2",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "templating",
     "transform"
   ],
-  "version": "4.4.0",
+  "version": "5.0.0",
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "license": "WTFPL",
   "repository": "domenic/jadeify",


### PR DESCRIPTION
I'm not sure, but I think to avoid such problems [#42] we should define peer dependency at least one version ahead. What do you think?