### PR TITLE
Bump browserify dev and peer dependency entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "through": "^2.3.6"
   },
   "peerDependencies": {
-    "browserify": ">= 2.4.0 < 13",
+    "browserify": ">= 2.4.0 < 14",
     "jade": "^1.9.2"
   },
   "devDependencies": {
-    "browserify": "^12.0.1",
+    "browserify": "^13.0.0",
     "concat-stream": "^1.5.0",
     "jade": "^1.11.0",
     "jsdom": "^7.0.2",


### PR DESCRIPTION
Since Browserify got bumped to v.13, this warning appeared when installing via npm:

`npm WARN EPEERINVALID jadeify@4.5.0 requires a peer of browserify@>= 2.4.0 < 13 but none was installed.`

There are no obvious breaking changes in Browserify's v.13, so simple bump should do the trick.