### PR TITLE
Fix dev dependency version indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "browserify": ">= 2.4.0 < 14",
-    "jade": "^1.9.2"
+    "jade": ">= 1.9.2"
   },
   "devDependencies": {
     "browserify": "^13.0.0",


### PR DESCRIPTION
I use this in a project with jade 1.9.1 and it throw an error when don't find the method ```compileClientWithDependenciesTracked```.

Reproduce it:
```
$ npm install --save jade@1.9.1 jadeify 
$ cat package.json| grep jade
    "jade": "^1.9.1",
    "jadeify": "^4.6.0"
```